### PR TITLE
Fix contracts for SPARK proofs

### DIFF
--- a/src/algos/line_finder/geo_filter.ads
+++ b/src/algos/line_finder/geo_filter.ads
@@ -57,7 +57,7 @@ package Geo_Filter is
    type Window_Type is array (1 .. Window_Size) of Point_Type;
 
    Window       : Window_Type := (others => State2PointLookup (Online));
-   Window_Index : Integer := Window_Type'First;
+   Window_Index : Integer range 1 .. Window_Size := Window_Type'First;
 
    --  This performs the filtering
    --  @param State pass the detected state here and received the computed
@@ -68,7 +68,7 @@ package Geo_Filter is
                           Thresh : out Boolean)
      with Global => (In_Out => (Window,
                                 Window_Index)),
-     Post => (Window_Index in Window_Type'Range and
+     Post => (if State'Old /= Unknown then
                 Window_Index /= Window_Index'Old);
 private
 

--- a/src/fusion/zumo_motion.ads
+++ b/src/fusion/zumo_motion.ads
@@ -13,10 +13,14 @@ package Zumo_Motion is
      with Global => (In_Out => (Initd,
                                 Zumo_LSM303.Initd,
                                 Zumo_L3gd20h.Initd)),
-     Pre => not Initd,
-     Post => Initd;
+     Pre => not Initd
+       and then not Zumo_LSM303.Initd
+       and then not Zumo_L3gd20h.Initd,
+     Post => Initd
+       and then Zumo_LSM303.Initd
+       and then Zumo_L3gd20h.Initd;
 
    function Get_Heading return Degrees
-     with Pre => Initd;
+     with Pre => Initd and Zumo_LSM303.Initd;
 
 end Zumo_Motion;


### PR DESCRIPTION
* src/algos/line_finder/geo_filter.ads
(Window_Index): Use more restricted range for variable type.
(Filter_State): Fix the postcondition to account for no change
 in Window_Index when State is Unknown on entry.

* src/fusion/zumo_motion.ads
(Init): Complete the contract regarding Initd flags in other units.
(Get_Heading): Complete precondition to allow internal call that
 expects Zumo_LSM303 to be initialized.